### PR TITLE
add license section on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ To make some DOM:
 crel is fast. Depending on what browser you use, it is up there with straight document.createElement calls.
 
 http://jsperf.com/dom-creation-libs
+
+# License #
+
+MIT


### PR DESCRIPTION
I added a section on the readme with the license type, I took the license type from the .js file header, I think it's MIT, let me know if it's a specific kind or I made a mistake.
