### PR TITLE
Specify the handling of different child types

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Signature:
 
     crel(tagName/dom element [, attributes, child1, child2, childN...])
 
+where `childN` may be
+
+ * a DOM element,
+ * a string, which will be inserted as a `textNode`,
+ * `null`, which will be ignored, or
+ * an `Array` containing any of the above
+
 For browserify:
 
     npm i crel


### PR DESCRIPTION
I found (and use quite a bit) some undocumented features in the source, and thought I'd include them in the readme.

I'm not sure if it is necessary (or desired) to include that `undefined` works in place of `null`, since it's only compared with `==` in the source.
