### PR TITLE
Replace `uglify-es` with terser & other small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ npm i crel
 ```
 
 ```javascript
-var crel = require('crel');
+let crel = require('crel');
 ```
 
 For AMD:
 
 ```javascript
 require.config({paths: { crel: 'https://cdnjs.cloudflare.com/ajax/libs/crel/4.0.1/crel.min' }});
-require(['crel'], function(crel) {
+require(['crel'], (crel) => {
     // Your code
 });
 ```
@@ -64,7 +64,7 @@ where `childN` may be:
 ## Examples
 
 ```javascript
-var element = crel('div',
+let element = crel('div',
     crel('h1', 'Crello World!'),
     crel('p', 'This is crel'),
     crel('input', { type: 'number' })
@@ -83,14 +83,14 @@ You can define custom functionality for certain keys seen in the attributes
 object:
 
 ```javascript
-crel.attrMap['on'] = function(element, value) {
-    for (var eventName in value) {
+crel.attrMap['on'] = (element, value) => {
+    for (let eventName in value) {
         element.addEventListener(eventName, value[eventName]);
     }
 };
 // Attaches an onClick event to the img element
 crel('img', { on: {
-    'click': function() {
+    click: () => {
         console.log('Clicked');
     }
 }});
@@ -105,8 +105,8 @@ crel(document.body, crel('h1', 'Page title'));
 You can assign child elements to variables during creation:
 
 ```javascript
-var button;
-var wrapper = crel('div',
+let button;
+let wrapper = crel('div',
     button  = crel('button')
 );
 ```
@@ -124,9 +124,9 @@ _But don't._
 If you are using Crel in an environment that supports Proxies, you can also use the new API:
 
 ```javascript
-var crel = require('crel').proxy;
+let crel = require('crel').proxy;
 
-var element = crel.div(
+let element = crel.div(
     crel.h1('Crello World!'),
     crel.p('This is crel'),
     crel.input({ type: 'number' })
@@ -135,7 +135,7 @@ var element = crel.div(
 
 # Browser support
 
-Crel works in all evergreen browsers.
+Crel uses ES6 features, so it'll work in all evergreen browsers.
 
 # Goals
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ var crel = require('crel');
 For AMD:
 
 ```javascript
-require.config({paths: { crel: 'https://cdnjs.cloudflare.com/ajax/libs/crel/3.1.0/crel.min' }});
+require.config({paths: { crel: 'https://cdnjs.cloudflare.com/ajax/libs/crel/4.0.1/crel.min' }});
 require(['crel'], function(crel) {
     // Your code
 });

--- a/crel.js
+++ b/crel.js
@@ -16,8 +16,6 @@ This might make it harder to read at times, but the code's intention should be t
         d = document,
         // Helper functions used throughout the script
         isType = (object, type) => typeof object === type,
-        isNode = (node) => node instanceof Node,
-        isElement = (object) => object instanceof Element,
         // Recursively appends children to given element. As a text node if not already an element
         appendChild = (element, child) => {
             if (child !== null) {
@@ -74,8 +72,8 @@ This might make it harder to read at times, but the code's intention should be t
 
     // Used for mapping attribute keys to supported versions in bad browsers, or to custom functionality
     crel.attrMap = {};
-    crel.isElement = isElement;
-    crel[isNodeString] = isNode;
+    crel.isElement = object => object instanceof Element;
+    crel[isNodeString] = node => node instanceof Node;
     // Expose proxy interface
     crel.proxy = new Proxy(crel, {
         get: (target, key) => {

--- a/crel.js
+++ b/crel.js
@@ -20,7 +20,7 @@ This might make it harder to read at times, but the code's intention should be t
         appendChild = (element, child) => {
             if (child !== null) {
                 if (Array.isArray(child)) { // Support (deeply) nested child elements
-                    child.map((subChild) => appendChild(element, subChild));
+                    child.map(subChild => appendChild(element, subChild));
                 } else {
                     if (!crel[isNodeString](child)) {
                         child = d.createTextNode(child);

--- a/crel.js
+++ b/crel.js
@@ -38,11 +38,8 @@ This might make it harder to read at times, but the code's intention should be t
             attribute;
         // If first argument is an element, use it as is, otherwise treat it as a tagname
         element = crel.isElement(element) ? element : d.createElement(element);
-        // Check if second argument is a settings object. Skip it if it's:
-        // - not an object (this includes `undefined`)
-        // - a Node
-        // - an array
-        if (!(!isType(settings, 'object') || crel[isNodeString](settings) || Array.isArray(settings))) {
+        // Check if second argument is a settings object
+        if (isType(settings, 'object') && !crel[isNodeString](settings) && !Array.isArray(settings)) {
             // Don't treat settings as a child
             index++;
             // Go through settings / attributes object, if it exists

--- a/package-lock.json
+++ b/package-lock.json
@@ -421,6 +421,12 @@
         "source-map": "~0.5.3"
       }
     },
+    "commander": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1605,6 +1611,24 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
+    "source-map-support": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+      "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "spdx-correct": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -1782,6 +1806,25 @@
         "uuid": "^3.0.1"
       }
     },
+    "terser": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-3.14.1.tgz",
+      "integrity": "sha512-NSo3E99QDbYSMeJaEk9YW2lTg3qS9V0aKGlb+PlOrei1X02r1wSBHCNX/O+yeTRFSWPKPIGj6MqvvdqV4rnVGw==",
+      "dev": true,
+      "requires": {
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.6"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -1830,30 +1873,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
-    },
-    "uglify-es": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-      "dev": true,
-      "requires": {
-        "commander": "~2.13.0",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
     },
     "umd": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "browserify": "^16.2.3",
     "opn-cli": "^4.0.0",
     "tape": "^4.9.2",
-    "uglify-es": "^3.3.9"
+    "terser": "^3.14.1"
   },
   "scripts": {
     "test": "npm run testBuild && opn ./test/test.html",
     "testBuild": "browserify ./test/index.js > ./test/index.browser.js",
-    "build": "uglifyjs crel.js -m -c --warn -o crel.min.js"
+    "build": "terser crel.js -o crel.min.js --warn --ecma 6 -c pure_getters -m"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "test": "npm run testBuild && opn ./test/test.html",
     "testBuild": "browserify ./test/index.js > ./test/index.browser.js",
-    "build": "terser crel.js -o crel.min.js --warn --ecma 6 -c pure_getters -m"
+    "build": "terser crel.js -o crel.min.js --warn --ecma 6 -c evaluate=false,pure_getters -m"
   },
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -84,6 +84,24 @@ test('Add an `onEvent` property to an element', function (t) {
     testElement.click();
 });
 
+test('Add an `onEvent` property to an element through attribute mapping', function (t) {
+    t.plan(1);
+
+    crel.attrMap.on = function (element, value) {
+        for (var eventName in value) {
+            element.addEventListener(eventName, value[eventName]);
+        }
+    };
+
+    var testElement = crel('img', { on: {
+        click: function () {
+            t.pass('onClick event triggered');
+        }
+    }});
+
+    testElement.click();
+});
+
 // -- Test child node handling --
 test('Create an element with a child element', function (t) {
     t.plan(2);


### PR DESCRIPTION
While working on crels proxy part (that'll be the last pull request I swear :P) I also made these other small changes that don't really belong there, so here:
- Replace unmaintained `uglify-es` with `terser`
- 4f15002 & c47e9f8 , the helper strings stopped working on my proxy branch after certain changes. I also had to move the `is*` functions to get the same sized minfile
- Small code style improvements
- Updates to readme now that the version number got bumped