### PR TITLE
Make sure es module is compiled to ES5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 *.browser.js
-*.mjs
+*.es.js

--- a/package.json
+++ b/package.json
@@ -7,14 +7,15 @@
   ],
   "version": "4.1.0",
   "main": "crel.js",
-  "module": "crel.mjs",
+  "module": "crel.es.js",
   "dependencies": {},
   "devDependencies": {
-    "tape-run": "^6.0.1",
+    "@rollup/plugin-buble": "^0.20.0",
     "browserify": "^16.2.3",
     "rollup": "^1.26.3",
     "rollup-plugin-commonjs": "^10.1.0",
     "tape": "^4.9.2",
+    "tape-run": "^6.0.1",
     "terser": "^3.14.1"
   },
   "files": [
@@ -22,7 +23,7 @@
     "README.md",
     "crel.js",
     "crel.min.js",
-    "crel.mjs",
+    "crel.es.js",
     "package.json"
   ],
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,10 +1,11 @@
 import commonjs from 'rollup-plugin-commonjs';
+import buble from '@rollup/plugin-buble'
 
 export default {
     input: 'crel.js',
     output: {
-        file: 'crel.mjs',
+        file: 'crel.es.js',
         format: 'esm'
     },
-    plugins: [commonjs()]
+    plugins: [commonjs(), buble()]
 };


### PR DESCRIPTION
related: #51, https://github.com/ProseMirror/prosemirror/issues/1003

# Problem


#51 introduced ESM, but it breaks our application because it includes ES6 features.


# Solution


Make ESM file to be compiled down to ES5.


---


I found the problem and solution from https://github.com/ProseMirror/prosemirror/issues/1003.
And this change is based on rope-sequence's one. https://github.com/marijnh/rope-sequence/commit/54d5180e1fc5509262fbb06df2f92ca5c407f495